### PR TITLE
Add `.ready()` API.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -34,6 +34,7 @@ Nasa.config = Nasa.core.config
 Nasa.query = Nasa.contract.query
 Nasa.call = Nasa.tx.call
 Nasa.checkTx = Nasa.tx.checkTx
+Nasa.ready = Nasa.util.ready
 
 // alias
 Nasa.ua.isNasNano = Nasa.ua.isWalletMobileApp

--- a/src/util/index.js
+++ b/src/util/index.js
@@ -23,3 +23,4 @@ export {
 	isValidPayId,
 	stripErrorMsgPrefix,
 }
+export { ready } from './ready'

--- a/src/util/ready.js
+++ b/src/util/ready.js
@@ -1,0 +1,66 @@
+import * as ua from '../ua/index'
+
+function isDomReady() {
+	return document.readyState === 'interactive' || document.readyState === 'complete'
+}
+
+// 逐个执行并清空队列中的任务
+const queue = []
+function handleQueue() {
+	while (queue.length) {
+		const task = queue.shift()
+		try {
+			task()
+		} catch (e) {
+			console.error(e)
+		}
+	}
+}
+
+// 此 Promise 包含的值表示 "钱包扩展是否可用" 这个问题的答案
+function getPromise() {
+	return new Promise((resolve, reject) => {
+		/** DEBUG_INFO_START **/
+		console.log('[Nasa.js] `.ready()` init promise.')
+		/** DEBUG_INFO_END **/
+
+		// 如果当前浏览器不可能支持钱包扩展，则答案确定 - 否
+		if (!ua.isDesktopChrome()) resolve(false)
+
+		// 如果钱包扩展已就绪，则答案确定 - 是
+		else if (ua.isWalletExtensionInstalled()) resolve(true)
+
+		// 如果到这里还没有得到答案，则尝试轮询
+		// 如果 DOM 已经 ready，则只给最后一次重试机会
+		else setTimeout(recheck, 100, isDomReady())
+
+		function recheck(isLastCheck) {
+			/** DEBUG_INFO_START **/
+			console.log('[Nasa.js] `.ready()` recheck, isLastCheck: ', isLastCheck)
+			/** DEBUG_INFO_END **/
+
+			// 如果钱包扩展已就绪，则答案确定 - 是
+			if (ua.isWalletExtensionInstalled()) resolve(true)
+
+			// 如果最后一次轮询机会还没有得出结论，则答案确定 - 否
+			else if (isLastCheck) resolve(false)
+
+			// 继续重试
+			else setTimeout(recheck, 100, isDomReady())
+		}
+	})
+}
+
+let promise
+export function ready(fn) {
+	if (typeof fn !== 'function') return
+	queue.push(fn)
+
+	if (!promise) promise = getPromise()
+	promise.then((value) => {
+		/** DEBUG_INFO_START **/
+		console.log('[Nasa.js] `.ready()` promise value: ', value)
+		/** DEBUG_INFO_END **/
+		handleQueue()
+	})
+}


### PR DESCRIPTION
## 背景

> #### `Nasa.ua.isWalletExtensionInstalled()` <a name="ua--isWalletExtensionInstalled">&nbsp;</a>
> 
> #### 返回值
> 
> 布尔值。判断 “星云钱包 Chrome 扩展” 是否已安装。
> 
> > 注：此功能依赖扩展向页面中注入的脚本来判断，而由于扩展注入脚本需要一点点时间，因此，在页面最顶部运行此 API 不一定会得到正确的结果。

## 解决方案

提供 `Nasa.ready()` API，其功能类似于 jQuery 的 `$(document).ready()` 方法。

应用把初始化函数传给它就可以了，它会选择在合适的时机执行，避免出现 “明明装了钱包扩展但判断为未装” 的问题。
